### PR TITLE
Changes to manifest for CIPHER corrected

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Before running `cf push`
 - Include a `ca.crt` file in this directory (CA that signed the expected client certs)
 
 ## Specifying Cipher suites while TLS or MTLS is enabled
-- When no cipher suite is provided, the [golang default](https://golang.org/pkg/crypto/tls/#pkg-constants) ciphers are loaded.
-- When the set of ciphers are specified and shared with the gorouter, the most preferred cipher (first one in the list) is used.
-- In `manifest.yml`
-    ```yaml
-    CIPHER: "ECDHE-RSA-AES128-GCM-SHA256:TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
+- When `CIPHER` key is not provided in `manifest.yml` the [golang default](https://golang.org/pkg/crypto/tls/#pkg-constants) ciphers are loaded.
+- To specify a cipher suite for the app, use `CIPHER` in `manifest.yml`; Gorouter must be configured to support the same cipher suite. Note: only one cipher suite is supported by `CIPHER`. For e.g. in `manifest.yml`
+ 
+   ```yaml
+    CIPHER: "ECDHE-RSA-AES128-GCM-SHA256"
     ```


### PR DESCRIPTION
GolangApp supports only one CIPHER, not a set of CIPHER's currently.