### PR TITLE
Removing CIPHER from default manifest as push app fails

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -9,4 +9,3 @@ applications:
     GOPACKAGENAME: golang-app
     TLS: false
     MTLS: false
-    CIPHER:


### PR DESCRIPTION
The default cf push golang-app fails because there is no value for `CIPHER`.